### PR TITLE
Fix TypeError on import caused by type annotation

### DIFF
--- a/src/cmake_parser/interpreter.py
+++ b/src/cmake_parser/interpreter.py
@@ -21,7 +21,7 @@ import re
 import os
 from attrs import define, evolve
 from functools import partial
-from typing import Dict, List, Tuple, Union, Callable, Any
+from typing import Dict, List, Tuple, Union, Callable, Any, Type
 from .ast import *
 from .lexer import Token, TokenGenerator
 from .error import CMakeExprError
@@ -258,7 +258,7 @@ def _version(s: str) -> Tuple[int, int, int, int]:
 
 
 def _eval_compare(
-    coerce: type[Any],
+    coerce: Type[Any],
     compare: Callable[[Any, Any], bool],
     ctx: Context,
     arg1: Token,


### PR DESCRIPTION
Hi, and thank you @roehling for open-sourcing this library! I'm finding it very useful for translating Vcpkg port files to Python.

I encountered a minor bug that was causing `TypeError` when importing `cmake_parser` in Python 3.8 and this PR proposes a fix for that.
```
Traceback (most recent call last):
  File "/home/martin/projects/teleport/main.py", line 3, in <module>
    import cmake_parser as cmp
  File "/home/martin/.local/lib/python3.8/site-packages/cmake_parser/__init__.py", line 20, in <module>
    from .interpreter import resolve_args
  File "/home/martin/.local/lib/python3.8/site-packages/cmake_parser/interpreter.py", line 261, in <module>
    coerce: type[Any],
TypeError: 'type' object is not subscriptable
```