### PR TITLE
Add project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ authors = [
 urls."Homepage" = "https://roehling.github.io/cmake_parser/"
 urls."Bug Reports" = "https://github.com/roehling/cmake_parser/issues"
 urls."Source" = "https://github.com/roehling/cmake_parser"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
 dependencies = [
     "attrs >= 21.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ license = {file = "LICENSES/Apache-2.0.txt"}
 authors = [
     { name = "Timo Röhling", email = "timo@gaussglocke.de"},
 ]
+urls."Homepage" = "https://roehling.github.io/cmake_parser/"
+urls."Bug Reports" = "https://github.com/roehling/cmake_parser/issues"
+urls."Source" = "https://github.com/roehling/cmake_parser"
 dependencies = [
     "attrs >= 21.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ license = {file = "LICENSES/Apache-2.0.txt"}
 authors = [
     { name = "Timo Röhling", email = "timo@gaussglocke.de"},
 ]
-urls."Homepage" = "https://roehling.github.io/cmake_parser/"
-urls."Bug Reports" = "https://github.com/roehling/cmake_parser/issues"
-urls."Source" = "https://github.com/roehling/cmake_parser"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
@@ -39,6 +36,10 @@ dependencies = [
     "attrs >= 21.3.0"
 ]
 dynamic = ["version"]
+
+[project.urls]
+Github = "https://github.com/roehling/cmake_parser"
+Documentation = "https://roehling.github.io/cmake_parser/"
 
 [tool.setuptools_scm]
 write_to = "src/cmake_parser/_version.py"


### PR DESCRIPTION
I recommend adding the following URLs for the PyPI sidebar, which makes it a bit easier to find the docs and determine the status of the project (whether it is maintained or not).

You could also add the following badges to the README.rst to link in the other direction as well. I've found these useful, but you definitely don't need to include these if they are not your cup of tea.
```rst
.. image:: https://img.shields.io/pypi/v/cmake_parser
    :target: https://pypi.org/project/cmake_parser/
.. image:: https://img.shields.io/pypi/dm/cmake_parser
    :target: https://pypistats.org/packages/cmake_parser
```
[![PyPI](https://img.shields.io/pypi/v/cmake_parser)](https://pypi.org/project/cmake_parser/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/cmake_parser)](https://pypistats.org/packages/cmake_parser)